### PR TITLE
Change Docker Mounting Point + Ignoring Include Files

### DIFF
--- a/apps/docs/docs/extended/ExtendedDiagram.dsl
+++ b/apps/docs/docs/extended/ExtendedDiagram.dsl
@@ -1,0 +1,9 @@
+workspace extends ../AmazonWebServicesDeployment.dsl {
+    name "Extended Workspace"
+    description "This workspace is an extension of the AmazonWebServicesDeployment workspace."
+
+    model {
+        !include include.model.dsl
+    }
+
+}

--- a/apps/docs/docs/extended/include.model.dsl
+++ b/apps/docs/docs/extended/include.model.dsl
@@ -1,0 +1,1 @@
+user = person "Included Person" "This DSL does not get included in the generated code as its an inclue file and not a workspace file denoted by the filename 'include.'"

--- a/apps/docs/docs/index.mdx
+++ b/apps/docs/docs/index.mdx
@@ -65,6 +65,7 @@ export default {
         executor: 'auto', // "docker" | "cli" | "auto",
         dockerImage: 'structurizr/cli', // see https://hub.docker.com/r/structurizr/cli
         additionalStructurizrArgs: undefined, // string
+        ignoreDSLFilesGlob: '/**/include.*.dsl', // automatically exclude import files (eg: !import ../common/import.actors.dsl)
       },
     ],
   ],

--- a/packages/docusaurus-plugin-structurizr/src/docusaurus-plugin-structurizer.ts
+++ b/packages/docusaurus-plugin-structurizr/src/docusaurus-plugin-structurizer.ts
@@ -19,7 +19,15 @@ export async function docusaurusPluginStructurizr(
   context: LoadContext,
   options: InternalDocusaurusPluginStructurizrOptions,
 ): Promise<Plugin> {
-  const { enabled, paths = [], format, executor, dockerImage, additionalStructurizrArgs } = options
+  const {
+    enabled,
+    paths = [],
+    format,
+    executor,
+    dockerImage,
+    additionalStructurizrArgs,
+    ignoreDSLFilesGlob,
+  } = options
 
   if (!enabled) {
     return {
@@ -34,13 +42,16 @@ export async function docusaurusPluginStructurizr(
     return `${resolvedPath}/**/*.dsl`
   })
 
+  // exclude "include" files
+  contentPaths.push(`!${context.siteDir}${ignoreDSLFilesGlob}`)
+
   return {
     name: PLUGIN_NAME,
     async loadContent() {
       const files = await findFiles(contentPaths)
       const results = await Promise.allSettled(
         files.map((file) =>
-          runStructurizr(file, {
+          runStructurizr(file, context.siteDir, {
             executor: detectedExecutor,
             dockerImage,
             format,

--- a/packages/docusaurus-plugin-structurizr/src/run-structurizr.ts
+++ b/packages/docusaurus-plugin-structurizr/src/run-structurizr.ts
@@ -9,18 +9,18 @@ import type { InternalDocusaurusPluginStructurizrOptions } from './validate-opti
  */
 export async function runStructurizr(
   file: string,
+  docsPath: string,
   options: Pick<
     InternalDocusaurusPluginStructurizrOptions,
     'executor' | 'dockerImage' | 'format' | 'additionalStructurizrArgs'
   >,
 ) {
   const { format, additionalStructurizrArgs, executor, dockerImage } = options
-  const directory = path.dirname(file)
-  const fileName = path.basename(file)
+  const fileName = path.relative(docsPath, file)
 
   const executorMap = {
     docker: [
-      `docker run --rm -v "${directory}:/usr/local/structurizr" ${dockerImage} export -workspace "${fileName}"`,
+      `docker run --rm -v "${docsPath}:/usr/local/structurizr" ${dockerImage} export -workspace "${fileName}"`,
       additionalStructurizrArgs,
     ]
       .filter(Boolean)

--- a/packages/docusaurus-plugin-structurizr/src/validate-options.ts
+++ b/packages/docusaurus-plugin-structurizr/src/validate-options.ts
@@ -61,6 +61,7 @@ const Schema = Joi.object<DocusaurusPluginStructurizrOptions>({
   executor: Joi.string().valid('docker', 'cli', 'auto').default('auto'),
   dockerImage: Joi.string().default('structurizr/cli'),
   additionalStructurizrArgs: Joi.string().default(''),
+  ignoreDSLFilesGlob: Joi.string().default('/**/include.*.dsl'),
 })
 
 export function validateOptions({

--- a/packages/docusaurus-plugin-structurizr/test/run-structurizr.test.ts
+++ b/packages/docusaurus-plugin-structurizr/test/run-structurizr.test.ts
@@ -13,7 +13,7 @@ describe('run-structurizr', () => {
   })
 
   it('should run structurizr with cli', async () => {
-    await runStructurizr('some-file.dsl', {
+    await runStructurizr('some-file.dsl', '.', {
       executor: 'cli',
       format: 'mermaid',
       dockerImage: 'structurizr/cli',
@@ -26,7 +26,7 @@ describe('run-structurizr', () => {
   })
 
   it('should run structurizr with docker', async () => {
-    await runStructurizr('some-file.dsl', {
+    await runStructurizr('some-file.dsl', '.', {
       executor: 'docker',
       format: 'mermaid',
       dockerImage: 'structurizr/cli',
@@ -38,9 +38,22 @@ describe('run-structurizr', () => {
     )
   })
 
+  it('should run structurizr with docker mounted with the correct dir', async () => {
+    await runStructurizr('/some-folder/some-file.dsl', '/some-folder/', {
+      executor: 'docker',
+      format: 'mermaid',
+      dockerImage: 'structurizr/cli',
+      additionalStructurizrArgs: '',
+    })
+
+    expect(exec).toHaveBeenCalledWith(
+      'docker run --rm -v "/some-folder/:/usr/local/structurizr" structurizr/cli export -workspace "some-file.dsl" -format "mermaid"',
+    )
+  })
+
   it('should throw if executor is unknown', async () => {
     expect(() =>
-      runStructurizr('some-file.dsl', {
+      runStructurizr('some-file.dsl', '.', {
         // @ts-expect-error - intentionally invalid value
         executor: 'unknown',
         format: 'mermaid',

--- a/packages/docusaurus-plugin-structurizr/test/validate-options.test.ts
+++ b/packages/docusaurus-plugin-structurizr/test/validate-options.test.ts
@@ -17,6 +17,7 @@ describe('validate options', () => {
         "executor": "auto",
         "format": "mermaid",
         "id": "default",
+        "ignoreDSLFilesGlob": "/**/include.*.dsl",
         "paths": [
           "docs",
         ],
@@ -28,6 +29,7 @@ describe('validate options', () => {
     const result = validateOptions({
       validate: normalizePluginOptions,
       options: {
+        ignoreDSLFilesGlob: 'overridden',
         additionalStructurizrArgs: 'overridden',
         dockerImage: 'overridden',
         enabled: false,
@@ -45,6 +47,7 @@ describe('validate options', () => {
         "executor": "cli",
         "format": "plantuml",
         "id": "overridden",
+        "ignoreDSLFilesGlob": "overridden",
         "paths": [
           "overridden1",
           "overridden2",


### PR DESCRIPTION
## 📝 Description

The current docker mount point is in the directory the DSL file is in, meaning you can't include a file from a directory above. For example if we have two workspaces with a common set of actors, its handy to include the persons in the one workspace, or to extend the workspace from a parent.

* common/
** include.persons.dsl
* project1/
** workspace.dsl
* project2/
** workspace.dsl

The same find all DSL files introduces a problem trying to create include files as it tries to generate a diagram from a file that isn't a workspace.

## ⛳️ Current behavior (updates)

Right now, the plugin will find all dsl files and try to generate a file in their current folder. When docker is used, it will mount the folder the file is in and use that file as a workspace.

Eg: `docker run --rm -v "/path/to/my/docs/some-doc/:/usr/local/structurizr" structurizr/cli export -workspace "some-file.dsl"`

* If some-file is supposed to be an include file, this will result in an error
* If the file includes or extends a workspace from a folder up, docker will not have it mounted

## 🚀 New behavior

The update changes how the `runStructurizr` will mounts the folder. We find the siteDir and use that to mount, then find the workspace relative to the siteDir:

Eg: `docker run --rm -v "/path/to/my/docs/:/usr/local/structurizr" structurizr/cli export -workspace "some-doc/some-file.dsl"`

We've also added a parameter for `ignoreDSLFilesGlob` so that include files can be excluded from the finding of dsl files.

By default this will match any file that starts with `include.`. This seems like an easier fix than opening each file to see if it contains a "workspace" keyword at the start or not

## 💣 Is this a breaking change (Yes/No):

Maybe..? Today each dsl file is treated as an dependent free file, this change allows you to depend on other files outside of the dsl file, and allows other files to be excluded. It's hard to imagine it conflicting with any other project as they would run into the issues described here first.
