### PR TITLE
feat: add support for output dir option

### DIFF
--- a/.changeset/thin-bags-bake.md
+++ b/.changeset/thin-bags-bake.md
@@ -1,0 +1,18 @@
+---
+'docusaurus-plugin-structurizr': minor
+---
+
+Support generating all diagrams in one output directory.
+
+By default, the option `outputDir` is `undefined` and all diagrams are generated in the same
+directory as the source file.
+
+Set `outputDir` to a string to generate all diagrams in a single directory relative to the
+docusaurus project root.
+
+```js
+const pluginOptions = {
+  // ...
+  outputDir: 'diagrams', // Generate all diagrams in a single directory. E.g. "diagrams".
+}
+```

--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ export default {
         executor: 'auto', // "docker" | "cli" | "auto",
         dockerImage: 'structurizr/cli', // see https://hub.docker.com/r/structurizr/cli
         additionalStructurizrArgs: undefined, // string
+        outputDir: undefined, // Generate all diagrams in a single directory. E.g. "diagrams".
         ignorePatterns: ['/**/include.*.dsl'], // automatically exclude import files (eg: !import ../common/import.actors.dsl)
       },
     ],

--- a/apps/docs/docs/index.mdx
+++ b/apps/docs/docs/index.mdx
@@ -65,6 +65,7 @@ export default {
         executor: 'auto', // "docker" | "cli" | "auto",
         dockerImage: 'structurizr/cli', // see https://hub.docker.com/r/structurizr/cli
         additionalStructurizrArgs: undefined, // string
+        outputDir: undefined, // Generate all diagrams in a single directory. E.g. "diagrams".
         ignorePatterns: ['/**/include.*.dsl'], // automatically exclude import files (eg: !import ../common/import.actors.dsl)
       },
     ],

--- a/packages/docusaurus-plugin-structurizr/README.md
+++ b/packages/docusaurus-plugin-structurizr/README.md
@@ -57,6 +57,7 @@ export default {
         executor: 'auto', // "docker" | "cli" | "auto",
         dockerImage: 'structurizr/cli', // see https://hub.docker.com/r/structurizr/cli
         additionalStructurizrArgs: undefined, // string
+        outputDir: undefined, // Generate all diagrams in a single directory. E.g. "diagrams".
         ignorePatterns: ['/**/include.*.dsl'], // automatically exclude import files (eg: !import ../common/import.actors.dsl)
       },
     ],

--- a/packages/docusaurus-plugin-structurizr/src/docusaurus-plugin-structurizer.ts
+++ b/packages/docusaurus-plugin-structurizr/src/docusaurus-plugin-structurizer.ts
@@ -27,6 +27,7 @@ export async function docusaurusPluginStructurizr(
     dockerImage,
     additionalStructurizrArgs,
     ignorePatterns,
+    outputDir,
   } = options
 
   if (!enabled) {
@@ -59,6 +60,7 @@ export async function docusaurusPluginStructurizr(
             dockerImage,
             format,
             additionalStructurizrArgs,
+            outputDir,
           }),
         ),
       )

--- a/packages/docusaurus-plugin-structurizr/src/run-structurizr.ts
+++ b/packages/docusaurus-plugin-structurizr/src/run-structurizr.ts
@@ -12,19 +12,30 @@ export async function runStructurizr(
   options: Pick<
     InternalDocusaurusPluginStructurizrOptions,
     'executor' | 'dockerImage' | 'format' | 'additionalStructurizrArgs'
-  > & { docsPath: string },
+  > &
+    Partial<Pick<InternalDocusaurusPluginStructurizrOptions, 'outputDir'>> & { docsPath: string },
 ) {
-  const { format, docsPath, additionalStructurizrArgs, executor, dockerImage } = options
+  const { format, docsPath, additionalStructurizrArgs, executor, dockerImage, outputDir } = options
   const fileName = path.relative(docsPath, file)
+  const resolvedOutputDir = outputDir ? path.resolve(outputDir) : ''
 
   const executorMap = {
     docker: [
-      `docker run --rm -v "${docsPath}:/usr/local/structurizr" ${dockerImage} export -workspace "${fileName}"`,
+      `docker run --rm`,
+      `-v "${docsPath}:/usr/local/structurizr"`,
+      resolvedOutputDir ? `-v "${resolvedOutputDir}:/usr/local/output"` : null,
+      dockerImage,
+      `export -workspace "${fileName}"`,
+      resolvedOutputDir ? `-output "/usr/local/output"` : null,
       additionalStructurizrArgs,
     ]
       .filter(Boolean)
       .join(' '),
-    cli: [`structurizr-cli export -workspace ${file}`, additionalStructurizrArgs]
+    cli: [
+      `structurizr-cli export -workspace ${file}`,
+      resolvedOutputDir ? `-output "${resolvedOutputDir}"` : null,
+      additionalStructurizrArgs,
+    ]
       .filter(Boolean)
       .join(' '),
     auto: '',

--- a/packages/docusaurus-plugin-structurizr/src/validate-options.ts
+++ b/packages/docusaurus-plugin-structurizr/src/validate-options.ts
@@ -55,6 +55,13 @@ export type DocusaurusPluginStructurizrOptions = PluginOptions & {
    * @default ['/**\/include.*.dsl']
    */
   ignorePatterns?: string[]
+
+  /**
+   * The output directory for the diagrams
+   * If not set, the diagrams will be generated in the same directory as the source file
+   * @default undefined
+   */
+  outputDir?: string
 }
 
 export type InternalDocusaurusPluginStructurizrOptions =
@@ -68,6 +75,7 @@ const Schema = Joi.object<DocusaurusPluginStructurizrOptions>({
   dockerImage: Joi.string().default('structurizr/cli'),
   additionalStructurizrArgs: Joi.string().default(''),
   ignorePatterns: Joi.array().items(Joi.string()).default(['/**/include.*.dsl']),
+  outputDir: Joi.string().optional(),
 })
 
 export function validateOptions({

--- a/packages/docusaurus-plugin-structurizr/test/run-structurizr.test.ts
+++ b/packages/docusaurus-plugin-structurizr/test/run-structurizr.test.ts
@@ -1,3 +1,4 @@
+import path from 'node:path'
 import { expect } from 'vitest'
 
 import { exec } from '../src/exec.js'
@@ -66,6 +67,40 @@ describe('run-structurizr', () => {
       }),
     ).rejects.toThrowErrorMatchingInlineSnapshot(
       `[Error: docusaurus-plugin-structurizr: Unknown executor: unknown]`,
+    )
+  })
+
+  it('should write files to output dir with executor docker', async () => {
+    const outputDir = 'my-output dir'
+    await runStructurizr('some-file.dsl', {
+      docsPath: '.',
+      executor: 'docker',
+      format: 'mermaid',
+      dockerImage: 'structurizr/cli',
+      additionalStructurizrArgs: '',
+      outputDir,
+    })
+
+    const resolvedPath = path.resolve(outputDir)
+    expect(exec).toHaveBeenCalledWith(
+      `docker run --rm -v ".:/usr/local/structurizr" -v "${resolvedPath}:/usr/local/output" structurizr/cli export -workspace "some-file.dsl" -output "/usr/local/output" -format "mermaid"`,
+    )
+  })
+
+  it('should write files to output dir with executor cli', async () => {
+    const outputDir = 'my-output dir'
+    await runStructurizr('some-file.dsl', {
+      docsPath: '.',
+      executor: 'cli',
+      format: 'mermaid',
+      dockerImage: '',
+      additionalStructurizrArgs: '',
+      outputDir,
+    })
+
+    const resolvedPath = path.resolve(outputDir)
+    expect(exec).toHaveBeenCalledWith(
+      `structurizr-cli export -workspace some-file.dsl -output "${resolvedPath}" -format "mermaid"`,
     )
   })
 })


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes #122

## 📝 Description

Support generating all diagrams in one output directory.

## ⛳️ Current behavior (updates)

By default, the option `outputDir` is `undefined` and all diagrams are generated in the same
directory as the source file.

## 🚀 New behavior

Set `outputDir` to a string to generate all diagrams in a single directory relative to the
docusaurus project root.

```js
const pluginOptions = {
  // ...
  outputDir: 'diagrams', // Generate all diagrams in a single directory. E.g. "diagrams".
}
```

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information
