### PR TITLE
feat: add logging after plugin start

### DIFF
--- a/.changeset/wild-glasses-ring.md
+++ b/.changeset/wild-glasses-ring.md
@@ -1,0 +1,5 @@
+---
+'docusaurus-plugin-structurizr': patch
+---
+
+Added logging after plugin started to improve usability.

--- a/packages/docusaurus-plugin-structurizr/src/docusaurus-plugin-structurizer.ts
+++ b/packages/docusaurus-plugin-structurizr/src/docusaurus-plugin-structurizer.ts
@@ -52,6 +52,7 @@ export async function docusaurusPluginStructurizr(
     name: PLUGIN_NAME,
     async loadContent() {
       const files = await findFiles(contentPaths)
+      logger.info('Generating diagrams...')
       const results = await Promise.allSettled(
         files.map((file) =>
           runStructurizr(file, {


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes # <!-- Github issue # here -->

## 📝 Description

> Add a brief description

Added some logging after plugin start to make it easier to understand if plugin did start properly when starting with in docusaurus context.

## ⛳️ Current behavior (updates)

> Please describe the current behavior that you are modifying

No logging after start. Unclear for users if plugin is actually running.

## 🚀 New behavior

> Please describe the behavior or changes this PR adds

Logging after start.

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing users. -->

No

## 📝 Additional Information
